### PR TITLE
Make db_create_indexes generic and export

### DIFF
--- a/R/dbi-s3.r
+++ b/R/dbi-s3.r
@@ -131,7 +131,15 @@ db_insert_into <- function(con, table, values, ...) {
   UseMethod("db_insert_into")
 }
 
+#' @name backend_db
+#' @export
 db_create_indexes <- function(con, table, indexes = NULL, unique = FALSE, ...) {
+  UseMethod("db_create_indexes")
+}
+
+#' @export
+db_create_indexes.DBIConnection <- function(con, table, indexes = NULL,
+  unique = FALSE, ...) {
   if (is.null(indexes)) return()
   assert_that(is.list(indexes))
 


### PR DESCRIPTION
Closes #1911 and this PR builds on PR #1915 (updating DB backend function docs).

Copied text from #1911 (for convenience): 

> Backends that require implementations of copy_to need to be able to access db_create_indexes. As this is not currently exported, backends will need to take a copy of this into their own code base. This seems unnecessary as there is nothing backend specific about this (simple for loop wrapper of db_create_index)
